### PR TITLE
Allow SSID with special characters

### DIFF
--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -40,7 +40,7 @@ if [ -f $CONFIG_FILE ]; then
     fi
 fi
 
-if echo "$LOCATION_NAMES" | egrep -q "^$SSID$"; then
+if echo "$LOCATION_NAMES" | grep -q "^$SSID$"; then
     NEW_LOCATION="$SSID"
 else
     if echo "$LOCATION_NAMES" | egrep -q "^Automatic$"; then


### PR DESCRIPTION
_Use 'grep' to interpret SSID with normal pattern matching instead of using 'egrep' with extended regular expression._

I had the problem to change the location to a SSID with special characters:

> [2017-12-27 13:07] Connected to '(.)(.) Boobies'
> [2017-12-27 13:07] Location '(.)(.) Boobies' was not found. Will default to 'Automatic'
> [2017-12-27 13:07] Changing the location to 'Automatic'

