### PR TITLE
Replace airport and scselect commands with the networksetup command.

### DIFF
--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -24,7 +24,7 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
-SSID=`networksetup -getairportnetwork en0 | awk '{print $NF}'`
+SSID=`networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork | awk '{print $NF}'`
 
 LOCATION_NAMES=`networksetup -listlocations`
 CURRENT_LOCATION=`networksetup -getcurrentlocation`

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -24,10 +24,10 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
-SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | grep ' SSID' | cut -d : -f 2- | sed 's/^[ ]*//'`
+SSID=`networksetup -getairportnetwork en0 | awk '{print $NF}'`
 
-LOCATION_NAMES=`scselect | tail -n +2 | cut -d \( -f 2- | sed 's/)$//'`
-CURRENT_LOCATION=`scselect | tail -n +2 | egrep '^\ +\*' | cut -d \( -f 2- | sed 's/)$//'`
+LOCATION_NAMES=`networksetup -listlocations`
+CURRENT_LOCATION=`networksetup -getcurrentlocation`
 
 ts "Connected to '$SSID'"
 


### PR DESCRIPTION
MacOS has a command called "networksetup" that seems easier to parse and has by default options to list all available network locations as well as the one that is currently active. 

This PR suggests replacing the current commands  to find the active SSID, list of available locations and currently active location, which currently use "scselect" and a not-in-path "airport" utility, with versions relying on the "networksetup" command.