### PR TITLE
Prefer networksetup and skip root runs

### DIFF
--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -24,7 +24,7 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
-SSID=`networksetup -getairportnetwork en0 | awk '{print $NF}'`
+SSID=`networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork | awk '{print $NF}'`
 
 LOCATION_NAMES=`networksetup -listlocations`
 CURRENT_LOCATION=`networksetup -getcurrentlocation`

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -24,10 +24,10 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
-SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | grep ' SSID' | cut -d : -f 2- | sed 's/^[ ]*//'`
+SSID=`networksetup -getairportnetwork en0 | awk '{print $NF}'`
 
-LOCATION_NAMES=`scselect | tail -n +2 | cut -d \( -f 2- | sed 's/)$//'`
-CURRENT_LOCATION=`scselect | tail -n +2 | egrep '^\ +\*' | cut -d \( -f 2- | sed 's/)$//'`
+LOCATION_NAMES=`networksetup -listlocations`
+CURRENT_LOCATION=`networksetup -getcurrentlocation`
 
 ts "Connected to '$SSID'"
 

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -24,6 +24,11 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
+if [ "$ID" == "root" ]; then
+    ts "Running as root will read a bad config, exiting."
+    exit 1;
+fi
+
 SSID=`networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork | awk '{print $NF}'`
 
 LOCATION_NAMES=`networksetup -listlocations`

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -21,14 +21,6 @@ ts() {
     date +"[%Y-%m-%d %H:%M] $*"
 }
 
-ID=`whoami`
-ts "I am '$ID'"
-
-if [ "$ID" == "root" ]; then
-    ts "Running as root will read a bad config, exiting."
-    exit 1;
-fi
-
 SSID=`ipconfig getsummary en0 | grep ' SSID' | awk -F ': ' '{print $2}'`
 
 LOCATION_NAMES=`networksetup -listlocations`

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -29,7 +29,7 @@ if [ "$ID" == "root" ]; then
     exit 1;
 fi
 
-SSID=`networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork | awk '{print $NF}'`
+SSID=`ipconfig getsummary en0 | grep ' SSID' | awk -F ': ' '{print $2}'`
 
 LOCATION_NAMES=`networksetup -listlocations`
 CURRENT_LOCATION=`networksetup -getcurrentlocation`


### PR DESCRIPTION
Primarily I wanted to incorporate @amartignoni's simplification through `networksetup` over use of a private API and implement a fix for issue #28 so that I had a one stop branch that would do what I needed. 

This covers both scenarios.

Closes #29 