### PR TITLE
Update SSID retrieval method post-macOS 15 (Seqouia). 

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -1,0 +1,8 @@
+This project is a fork of the original project by https://github.com/eprev, found at https://github.com/eprev/locationchanger (2020-2021). 
+No issues or PRs have been acted upon by the author in 5 years. Efforts will be made to encourage a merge or transfer of the project to this repo.
+I forked the project in order to preserve and allow the Community to continue support, if they so choose.
+
+This original is unlicensed at the time of publication (thus preserving the author's rights to the source code) so I have applied the MIT License 
+to this fork to clarify usage rights for future users. Should the author respond to my PR or otherwise contacts me, I will be happy to amend this file.
+
+Reference: https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#5-license-grant-to-other-users

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Paul Bernicchi
+Copyright (c) 2020-2021 https://github.com/eprev/locationchanger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ This project is a fork of the original project by https://github.com/eprev, foun
 https://github.com/eprev/locationchanger (2020-2021). No issues or PRs have been acted upon by the author
 in 5 years. Efforts will be made to encourage a merge or transfer of the project to this repo.
 
-This original was unlicensed so I have applied the MIT License to this fork to clarify usage rights for future users.
+More information on attributon can be found in the [CONTRIB.md](https://github.com/pbernicchi/locationchanger/blob/master/CONTRIB.md) stub.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,45 @@
 # Location Changer
 
-It automatically changes OS X’s [network location](https://support.apple.com/en-us/HT202480)
-based on the name of Wi-Fi network and runs arbitrary scrips when it happens.
+This script automatically changes macOS's [network location](https://support.apple.com/en-us/HT202480)
+based on the name of the active Wi-Fi network (SSID) and runs custom (user-supplied) scripts when 
+the network state changes, say, for changing proxy settings or mounting remote SMB shares.
+
+**Note: the original method is thought to have broken with macOS 15 (Sequoia) due to framework
+privacy settings, resulting in either null script results or `<redacted>`.
+
+The key functionality - the retrieval of the current Wi-Fi SSID triggering the location change and
+any optional scripts - has been reworked and confirmed to work udner macOS 26.3.1 (Tahoe). While
+the script does invoke `sudo` to create/install the script and LaunchAgents, it is rootless from
+there on out.
 
 ## Installation & Update
 
 ```
-curl -L https://github.com/eprev/locationchanger/raw/master/locationchanger.sh | bash
+curl -L https://github.com/pbernicchi/locationchanger/raw/master/locationchanger.sh | bash
 ```
 
-It will ask you for a root password to install `locationchanger` to the */usr/local/bin* directory.
+It will ask you for a root password to install `locationchanger` to the */usr/local/bin*
+directory.
 
-## Basic usage
+**NOTE:**You may wish to install to another directory like */opt/homebrew/bin*. If you do,
+omit the `| bash` from the `curl` command above so the script only downloads. You can edit
+the `INSTALL_DIR` at the top of the script to whatever you want, and also change the LaunchAgent
+path at the bottom of the script (line #6 below):
+
+```
+<dict>
+    <key>Label</key>
+    <string>org.eprev.locationchanger</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/locationchanger</string> <!-- ENSURE THIS PATH TO MATCH $INSTALL_DIR -->
+    </array>
+```
+
+Then save and manually run the install script as yourself. (`./locationchanger.sh`)
+
+
+## Basic Usage
 
 You have to name network locations after Wi-Fi networks. Let’s say, you need to have
 a specific network preferences for “Corp Wi-Fi” wireless network, then you have to create
@@ -43,9 +71,13 @@ exec 2>&1
 osascript -e 'tell application "System Events" to set require password to wake of security preferences to false'
 ```
 
+
 ## Aliasing
 
-If you want to share one network location between different wireless networks (for instance, you have a wireless router which broadcasts on 2.4 and 5GHz bands simultaneously), then you can create a configuration file *~/.locations/locations.conf* (plain text file with simple key-value pairs, no spaces in between):
+If you want to share one network location between different wireless networks (for instance, 
+you have a wireless router which broadcasts on 2.4 and 5GHz bands simultaneously), then you can create
+a configuration file *~/.locations/locations.conf* (plain text file with simple key-value pairs, no 
+spaces in between):
 
 ```bash
 Wi-Fi_5GHz=Wi-Fi
@@ -53,9 +85,10 @@ Wi-Fi_5GHz=Wi-Fi
 
 Where the keys are the wireless network names and the values are the desired location names.
 
+
 ## Troubleshooting
 
-It writes quite extensive information to the log file every time the wireless network changes:
+This script writes helpful information to the log file every time the wireless network changes:
 
 ```bash
 tail -f ~/Library/Logs/LocationChanger.log
@@ -69,3 +102,12 @@ Will switch the location to 'Wi-Fi' (configuration file)
 Changing the location to 'Wi-Fi'
 Running '~/.locations/Wi-Fi'
 ```
+
+
+## Credits
+
+This project is a fork of the original project by https://github.com/eprev, found at 
+https://github.com/eprev/locationchanger (2020-2021). No issues or PRs have been acted upon by the author
+in 5 years. Efforts will be made to encourage a merge or transfer of the project to this repo.
+
+This original was unlicensed so I have applied the MIT License to this fork to clarify usage rights for future users.

--- a/locationchanger.sh
+++ b/locationchanger.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# You can change INSTALL_DIR but ensure the LaunchAgent path (currently line 89) is edited to match or this will not run in the background
 INSTALL_DIR=/usr/local/bin
 SCRIPT_NAME=$INSTALL_DIR/locationchanger
 LAUNCH_AGENTS_DIR=$HOME/Library/LaunchAgents
@@ -24,7 +25,7 @@ ts() {
 ID=`whoami`
 ts "I am '$ID'"
 
-SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | grep ' SSID' | cut -d : -f 2- | sed 's/^[ ]*//'`
+SSID=`ipconfig getsummary en0 | grep ' SSID' | awk '{print $3}'`
 
 LOCATION_NAMES=`scselect | tail -n +2 | cut -d \( -f 2- | sed 's/)$//'`
 CURRENT_LOCATION=`scselect | tail -n +2 | egrep '^\ +\*' | cut -d \( -f 2- | sed 's/)$//'`
@@ -83,7 +84,7 @@ cat > $PLIST_NAME << EOT
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>org.eprev.locationchanger</string>
+    <string>org.pbernicchi.locationchanger</string>
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/locationchanger</string>


### PR DESCRIPTION
For macOS 15 (Sequoia) and newer versions, several modern alternatives exist to retrieve the current Wi-Fi SSID from the command line, as the legacy `airport` utility contained in `/System/Library/PrivateFrameworks/Apple80211.framework` has been deprecated.

Apple recommended `wdutil` as the intended replacement for `airport` but this requires `sudo` to run - infeasible as a LaunchAgent. The proposed method in this PR does the same thing and respects SSIDs with spaces.

Developed and tested under macOS 26.3.1 (Tahoe)

Note: I have incorporated this into my own fork at https://github.com/pbernicchi/locationchanger if you wish to transfer this repo to me, given the inactivity or I can make my forked repo **standalone**. With gratitude, of course, since I have been using this script for YEARS and I recall you doing us a solid by updating it about 5 years ago.